### PR TITLE
fix: Replace Devantler.CLIRunner with CLIWrap for command execution

### DIFF
--- a/src/Devantler.K9sCLI/Devantler.K9sCLI.csproj
+++ b/src/Devantler.K9sCLI/Devantler.K9sCLI.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devantler.CLIRunner" Version="1.0.36" />
+    <PackageReference Include="CLIWrap" Version="3.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Devantler.K9sCLI/K9s.cs
+++ b/src/Devantler.K9sCLI/K9s.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using CliWrap;
+using CliWrap.Buffered;
 using Devantler.CLIRunner;
 
 namespace Devantler.K9sCLI;
@@ -58,11 +59,15 @@ public static class K9s
     bool includeStdErr = true,
     CancellationToken cancellationToken = default)
   {
-    return await CLI.RunAsync(
-      Command.WithArguments(arguments),
-      validation: validation,
-      silent: silent,
-      includeStdErr: includeStdErr,
-      cancellationToken: cancellationToken).ConfigureAwait(false);
+    using var stdIn = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardInput();
+    using var stdErr = Console.OpenStandardError();
+    var command = Command.WithArguments(arguments)
+      .WithValidation(validation)
+      .WithStandardInputPipe(PipeSource.FromStream(stdIn))
+      .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
+      .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
+    var result = await command.ExecuteBufferedAsync(cancellationToken);
+    return (result.ExitCode, result.StandardOutput + result.StandardError);
   }
 }

--- a/src/Devantler.K9sCLI/K9s.cs
+++ b/src/Devantler.K9sCLI/K9s.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 using CliWrap;
 using CliWrap.Buffered;
-using Devantler.CLIRunner;
 
 namespace Devantler.K9sCLI;
 

--- a/src/Devantler.K9sCLI/K9s.cs
+++ b/src/Devantler.K9sCLI/K9s.cs
@@ -59,11 +59,11 @@ public static class K9s
     CancellationToken cancellationToken = default)
   {
     using var stdIn = Console.OpenStandardInput();
-    using var stdOut = Console.OpenStandardInput();
+    using var stdOut = Console.OpenStandardOutput();
     using var stdErr = Console.OpenStandardError();
     var command = Command.WithArguments(arguments)
       .WithValidation(validation)
-      .WithStandardInputPipe(PipeSource.FromStream(stdIn))
+      .WithStandardInputPipe(silent ? PipeSource.Null : PipeSource.FromStream(stdIn))
       .WithStandardOutputPipe(silent ? PipeTarget.Null : PipeTarget.ToStream(stdOut))
       .WithStandardErrorPipe(silent || !includeStdErr ? PipeTarget.Null : PipeTarget.ToStream(stdErr));
     var result = await command.ExecuteBufferedAsync(cancellationToken);


### PR DESCRIPTION
Switch to CLIWrap for improved command execution and update related code accordingly.