### PR TITLE
Refactor GetBinaryPath to GetCommand and update tests

### DIFF
--- a/src/Devantler.K9sCLI/Devantler.K9sCLI.csproj
+++ b/src/Devantler.K9sCLI/Devantler.K9sCLI.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CLIWrap" Version="3.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="runtimes/*/native/*">
       <Link>%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Devantler.K9sCLI/K9s.cs
+++ b/src/Devantler.K9sCLI/K9s.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
+using CliWrap;
 
 namespace Devantler.K9sCLI;
 
@@ -12,9 +12,9 @@ public static class K9s
   /// <summary>
   /// The K9s CLI command.
   /// </summary>
-  static string BinaryPath => GetBinaryPath();
+  static Command Command => GetCommand();
 
-  internal static string GetBinaryPath(PlatformID? platformID = default, Architecture? architecture = default, string? runtimeIdentifier = default)
+  internal static Command GetCommand(PlatformID? platformID = default, Architecture? architecture = default, string? runtimeIdentifier = default)
   {
     platformID ??= Environment.OSVersion.Platform;
     architecture ??= RuntimeInformation.ProcessArchitecture;
@@ -39,7 +39,7 @@ public static class K9s
     {
       File.SetUnixFileMode(binaryPath, UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute);
     }
-    return binaryPath;
+    return Cli.Wrap(binaryPath);
   }
 
   /// <summary>
@@ -55,7 +55,7 @@ public static class K9s
     // call k9s binary with the given arguments without cliwrap
     var process = new ProcessStartInfo
     {
-      FileName = BinaryPath,
+      FileName = Command.TargetFilePath,
       Arguments = string.Join(' ', arguments),
       UseShellExecute = true,
       CreateNoWindow = true,

--- a/tests/Devantler.K9sCLI.Tests/K9sTests/GetCommandTests.cs
+++ b/tests/Devantler.K9sCLI.Tests/K9sTests/GetCommandTests.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 namespace Devantler.K9sCLI.Tests.K9sTests;
 
 /// <summary>
-/// Tests for the <see cref="K9s.GetBinaryPath(PlatformID?, Architecture?, string?)"/> method.
+/// Tests for the <see cref="K9s.GetCommand(PlatformID?, Architecture?, string?)"/> method.
 /// </summary>
 public class GetCommandTests
 {
@@ -18,7 +18,7 @@ public class GetCommandTests
       string expectedBinary = "k9s-osx-x64";
 
       // Act
-      string actualBinary = Path.GetFileName(K9s.GetBinaryPath(PlatformID.Unix, Architecture.X64, "osx-x64"));
+      string actualBinary = Path.GetFileName(K9s.GetCommand(PlatformID.Unix, Architecture.X64, "osx-x64").TargetFilePath);
 
       // Assert
       Assert.Equal(expectedBinary, actualBinary);
@@ -35,7 +35,7 @@ public class GetCommandTests
     string expectedBinary = "k9s-osx-arm64";
 
     // Act
-    string actualBinary = Path.GetFileName(K9s.GetBinaryPath(PlatformID.Unix, Architecture.Arm64, "osx-arm64"));
+    string actualBinary = Path.GetFileName(K9s.GetCommand(PlatformID.Unix, Architecture.Arm64, "osx-arm64").TargetFilePath);
 
     // Assert
     Assert.Equal(expectedBinary, actualBinary);
@@ -51,7 +51,7 @@ public class GetCommandTests
     string expectedBinary = "k9s-linux-arm64";
 
     // Act
-    string actualBinary = Path.GetFileName(K9s.GetBinaryPath(PlatformID.Unix, Architecture.Arm64, "linux-arm64"));
+    string actualBinary = Path.GetFileName(K9s.GetCommand(PlatformID.Unix, Architecture.Arm64, "linux-arm64").TargetFilePath);
 
     // Assert
     Assert.Equal(expectedBinary, actualBinary);
@@ -67,7 +67,7 @@ public class GetCommandTests
     string expectedBinary = "k9s-win-x64.exe";
 
     // Act
-    string actualBinary = Path.GetFileName(K9s.GetBinaryPath(PlatformID.Win32NT, Architecture.X64, "win-x64"));
+    string actualBinary = Path.GetFileName(K9s.GetCommand(PlatformID.Win32NT, Architecture.X64, "win-x64").TargetFilePath);
 
     // Assert
     Assert.Equal(expectedBinary, actualBinary);
@@ -83,7 +83,7 @@ public class GetCommandTests
     string expectedBinary = "k9s-win-arm64.exe";
 
     // Act
-    string actualBinary = Path.GetFileName(K9s.GetBinaryPath(PlatformID.Win32NT, Architecture.Arm64, "win-arm64"));
+    string actualBinary = Path.GetFileName(K9s.GetCommand(PlatformID.Win32NT, Architecture.Arm64, "win-arm64").TargetFilePath);
 
     // Assert
     Assert.Equal(expectedBinary, actualBinary);
@@ -101,7 +101,7 @@ public class GetCommandTests
     string runtimeIdentifier = "wasm";
 
     // Act
-    void Act() => K9s.GetBinaryPath(platformID, architecture, runtimeIdentifier);
+    void Act() => K9s.GetCommand(platformID, architecture, runtimeIdentifier);
 
     // Assert
     _ = Assert.Throws<PlatformNotSupportedException>(Act);


### PR DESCRIPTION
Replace the GetBinaryPath method with GetCommand, utilizing the CLIWrap package for command execution. Update related tests to reflect this change.